### PR TITLE
Batch queries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    byebug (9.0.6)
     couchrest (1.1.3)
       mime-types (~> 1.15)
       multi_json (~> 1.0)
@@ -46,6 +47,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   couch_tap!
   mocha
   sqlite3

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.test_files = FileList.new('test/unit/**/*.rb')
+  t.test_files = FileList.new('test/**/*.rb')
 end
 
 desc "Run tests"

--- a/couch_tap.gemspec
+++ b/couch_tap.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "test-unit"
+  s.add_development_dependency "byebug"
 end

--- a/lib/couch_tap.rb
+++ b/lib/couch_tap.rb
@@ -42,7 +42,7 @@ module CouchTap
 
   def prepare_logger
     log = Logger.new(STDOUT)
-    log.level = Logger::INFO
+    log.level = ENV.fetch('log_level', Logger::INFO).to_i
     log
   end
 

--- a/lib/couch_tap.rb
+++ b/lib/couch_tap.rb
@@ -16,7 +16,7 @@ require 'couch_tap/builders/collection'
 require 'couch_tap/builders/table'
 require 'couch_tap/destroyers/collection'
 require 'couch_tap/destroyers/table'
-
+require 'couch_tap/query_executor'
 
 module CouchTap
   extend self

--- a/lib/couch_tap/builders/collection.rb
+++ b/lib/couch_tap/builders/collection.rb
@@ -19,9 +19,9 @@ module CouchTap
         instance_eval(&block)
       end
 
-      def execute
+      def execute(query_executor)
         @_tables.each do |table|
-          table.execute
+          table.execute(query_executor)
         end
       end
 

--- a/lib/couch_tap/builders/table.rb
+++ b/lib/couch_tap/builders/table.rb
@@ -82,7 +82,7 @@ module CouchTap
       def execute(query_executor)
         # Insert the record and prepare ID for sub-tables
         # dataset.insert(attributes§)
-        query_executor.insert(name, attributes)
+        query_executor.insert(name, parent.is_a?(DocumentHandler), id, attributes)
 
         # TODO remove this?
         set_attribute(primary_keys.last, id) unless id.blank?

--- a/lib/couch_tap/builders/table.rb
+++ b/lib/couch_tap/builders/table.rb
@@ -79,15 +79,18 @@ module CouchTap
 
       #### Support Methods
 
-      def execute
+      def execute(query_executor)
         # Insert the record and prepare ID for sub-tables
-        dataset.insert(attributes)
+        # dataset.insert(attributes§)
+        query_executor.insert(name, attributes)
+
+        # TODO remove this?
         set_attribute(primary_keys.last, id) unless id.blank?
 
         # Now go through each collection entry
         if @_collections.length > 0
           @_collections.each do |collection|
-            collection.execute
+            collection.execute(query_executor)
           end
         end
       end
@@ -97,15 +100,6 @@ module CouchTap
 
       def schema
         handler.schema(name)
-      end
-
-      def dataset
-        database[name]
-      end
-
-      def find_existing_row_and_set_attributes
-        row = dataset.where(key_filter).first
-        attributes.update(row) if row.present?
       end
 
       # Set the primary keys in the attributes so that the insert request

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -128,10 +128,6 @@ module CouchTap
       end
     end
 
-    def fetch_document(id)
-      source.get(id)
-    end
-
     def find_document_handlers(document)
       @handlers.reject{ |row| !row.handles?(document) }
     end

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -100,7 +100,7 @@ module CouchTap
     def process_row(row)
       # Sometimes CouchDB will send an update to keep the connection alive
       if id  = row['id']
-        logger.info "Processing Document with id #{id}"
+        logger.debug "Processing Document with id #{id} in #{source.name}"
         # Wrap the whole request in a transaction
         @query_executor.row row['seq'] do
           if row['deleted']

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -71,6 +71,7 @@ module CouchTap
       end
 
       # Make sure the request has the latest sequence
+      # TODO transfer seq owhership to the query executor and just grab the value here
       query = {:since => seq, :feed => 'continuous', :heartbeat => COUCHDB_HEARTBEAT * 1000,
                :include_docs => true}
 
@@ -105,7 +106,7 @@ module CouchTap
         seq = row['seq']
 
         # Wrap the whole request in a transaction
-        database.transaction do
+        @query_executor.transaction do
           if row['deleted']
             # Delete all the entries
             logger.info "#{source.name}: received DELETE seq. #{seq} id: #{id}"

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -106,7 +106,7 @@ module CouchTap
         seq = row['seq']
 
         # Wrap the whole request in a transaction
-        @query_executor.transaction do
+        @query_executor.row do
           if row['deleted']
             # Delete all the entries
             logger.info "#{source.name}: received DELETE seq. #{seq} id: #{id}"

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -98,9 +98,7 @@ module CouchTap
     end
 
     def process_row(row)
-      t1 = Time.now
       id  = row['id']
-
       # Sometimes CouchDB will send an update to keep the connection alive
       if id
         seq = row['seq']
@@ -109,8 +107,8 @@ module CouchTap
         @query_executor.row do
           if row['deleted']
             # Delete all the entries
-            logger.info "#{source.name}: received DELETE seq. #{seq} id: #{id}"
             handlers.each{ |handler| handler.delete({ '_id' => id }, @query_executor) }
+            # logger.info "#{doc['type']}: received DELETE seq. #{seq} id: #{id}"
           else
             doc = row['doc']
             find_document_handlers(doc).each do |handler|
@@ -118,9 +116,10 @@ module CouchTap
               handler.delete(doc, @query_executor)
               handler.insert(doc, @query_executor)
             end
-            logger.info "#{source.name}: received CHANGE seq: #{seq} id: #{id})"
+            # logger.info "#{doc['type']}: received CHANGE seq: #{seq} id: #{id})"
           end
-          self.seq = @query_executor.update_sequence(seq)
+          self.seq = seq
+          seq
         end # transaction
 
       elsif row['last_seq']

--- a/lib/couch_tap/changes.rb
+++ b/lib/couch_tap/changes.rb
@@ -100,6 +100,7 @@ module CouchTap
     def process_row(row)
       # Sometimes CouchDB will send an update to keep the connection alive
       if id  = row['id']
+        logger.info "Processing Document with id #{id}"
         # Wrap the whole request in a transaction
         @query_executor.row row['seq'] do
           if row['deleted']

--- a/lib/couch_tap/destroyers/collection.rb
+++ b/lib/couch_tap/destroyers/collection.rb
@@ -18,10 +18,10 @@ module CouchTap
         instance_eval(&block)
       end
 
-      def execute
+      def execute(query_executor)
         # Just go through each table and ask it to execute itself
         @_tables.each do |table|
-          table.execute
+          table.execute(query_executor)
         end
       end
 

--- a/lib/couch_tap/destroyers/table.rb
+++ b/lib/couch_tap/destroyers/table.rb
@@ -31,8 +31,8 @@ module CouchTap
       end
 
       def execute(query_executor)
-        query_executor.delete(name, key_filter)
-        
+        query_executor.delete(name, parent.is_a?(DocumentHandler), key_filter)
+
         @_collections.each do |collection|
           collection.execute(query_executor)
         end

--- a/lib/couch_tap/destroyers/table.rb
+++ b/lib/couch_tap/destroyers/table.rb
@@ -30,11 +30,11 @@ module CouchTap
         instance_eval(&block) if block_given?
       end
 
-      def execute
-        dataset = handler.database[name]
-        dataset.where(key_filter).delete
+      def execute(query_executor)
+        query_executor.delete(name, key_filter)
+        
         @_collections.each do |collection|
-          collection.execute
+          collection.execute(query_executor)
         end
       end
 

--- a/lib/couch_tap/document_handler.rb
+++ b/lib/couch_tap/document_handler.rb
@@ -3,7 +3,7 @@ module CouchTap
   class DocumentHandler
 
     attr_reader :changes, :filter, :mode
-    attr_accessor :id, :document
+    attr_accessor :id, :document, :query_executor
 
     def initialize(changes, filter = {}, &block)
       @changes  = changes
@@ -24,9 +24,9 @@ module CouchTap
     # Handle a table definition.
     def table(name, opts = {}, &block)
       if @mode == :delete
-        Destroyers::Table.new(self, name, opts, &block).execute
+        Destroyers::Table.new(self, name, opts, &block).execute(query_executor)
       elsif @mode == :insert
-        Builders::Table.new(self, name, opts, &block).execute
+        Builders::Table.new(self, name, opts, &block).execute(query_executor)
       end
     end
 
@@ -48,15 +48,17 @@ module CouchTap
       document['_id']
     end
 
-    def insert(document)
+    def insert(document, query_executor)
       @mode = :insert
       self.document = document
+      self.query_executor = query_executor
       instance_eval(&@_block)
     end
 
-    def delete(document)
+    def delete(document, query_executor)
       @mode = :delete
       self.document = document
+      self.query_executor = query_executor
       instance_eval(&@_block)
     end
 
@@ -65,7 +67,7 @@ module CouchTap
     end
 
     def database
-      changes.database
+      query_executor.database
     end
 
   end

--- a/lib/couch_tap/query_buffer.rb
+++ b/lib/couch_tap/query_buffer.rb
@@ -1,0 +1,90 @@
+
+module CouchTap
+  class QueryBuffer
+    include Enumerable
+
+    def initialize()
+      @buffer = {}
+      @size = 0
+    end
+
+    def insert(entity, top_level, id, attributes)
+      get_or_create(entity, top_level).insert(id, attributes)
+      @size += 1
+    end
+
+    def delete(entity, top_level, key, id)
+      get_or_create(entity, top_level).delete(key, id)
+      @size += 1
+    end
+
+    def clear
+      @size = 0
+      @buffer = {}
+    end
+
+    def each(&block)
+      @buffer.values.each &block
+    end
+
+    private
+
+    def get_or_create(entity, top_level)
+      unless @buffer.has_key?(entity)
+        @buffer[entity] = Entity.new(entity, top_level)
+      end
+      @buffer[entity]
+    end
+  end
+
+  class Entity
+    attr_reader :name, :primary_key
+
+    def initialize(name, top_level)
+      @deletes = Set.new
+      @primary_key = nil
+      @top_level = top_level
+      @inserts = top_level ? {} : []
+      @name = name
+    end
+
+    def insert(id, data)
+      if @top_level
+        @inserts[id] = data
+      else
+        @inserts << data
+      end
+    end
+
+    def delete(key, id)
+      if @primary_key && @primary_key != key
+        raise "More than one primary key used for deletion at #{@name}: [#{@primary_key}, #{key}]"
+      end
+      @primary_key = key
+      @deletes << id
+    end
+
+    def deletes
+      @deletes.to_a
+    end
+
+    def insert_values
+      (@top_level ? @inserts.values : @inserts).map do |data|
+        insert_keys.map { |k| data[k] }
+      end
+    end
+
+    def insert_keys
+      @insert_keys ||= (@top_level ? @inserts.first[1] : @inserts.first).keys
+    end
+
+    def any_delete?
+      @deletes.any?
+    end
+
+    def any_insert?
+      @inserts.any?
+    end
+  end
+end
+

--- a/lib/couch_tap/query_buffer.rb
+++ b/lib/couch_tap/query_buffer.rb
@@ -68,14 +68,10 @@ module CouchTap
       @deletes.to_a
     end
 
-    def insert_values
+    def insert_values(keys)
       (@top_level ? @inserts.values : @inserts).map do |data|
-        insert_keys.map { |k| data[k] }
+        keys.map { |k| data[k] }
       end
-    end
-
-    def insert_keys
-      @insert_keys ||= (@top_level ? @inserts.first[1] : @inserts.first).keys
     end
 
     def any_delete?

--- a/lib/couch_tap/query_buffer.rb
+++ b/lib/couch_tap/query_buffer.rb
@@ -30,15 +30,16 @@ module CouchTap
     private
 
     def get_or_create(entity, top_level)
-      unless @buffer.has_key?(entity)
-        @buffer[entity] = Entity.new(entity, top_level)
+      item = @buffer[entity] ||= Entity.new(entity, top_level)
+      if item.top_level != top_level
+        raise ArgumentError, "Cannot have entity #{entity} both as top level and as a dependent entity"
       end
-      @buffer[entity]
+      return item
     end
   end
 
   class Entity
-    attr_reader :name, :primary_key
+    attr_reader :name, :primary_key, :top_level
 
     def initialize(name, top_level)
       @deletes = Set.new
@@ -62,6 +63,9 @@ module CouchTap
       end
       @primary_key = key
       @deletes << id
+      if top_level
+        @inserts.delete id
+      end
     end
 
     def deletes

--- a/lib/couch_tap/query_buffer.rb
+++ b/lib/couch_tap/query_buffer.rb
@@ -45,15 +45,15 @@ module CouchTap
       @deletes = Set.new
       @primary_key = nil
       @top_level = top_level
-      @inserts = top_level ? {} : []
+      @inserts = {}
       @name = name
     end
 
     def insert(id, data)
       if @top_level
-        @inserts[id] = data
+        @inserts[id] = [data]
       else
-        @inserts << data
+        (@inserts[id] ||= []) << data
       end
     end
 
@@ -63,9 +63,7 @@ module CouchTap
       end
       @primary_key = key
       @deletes << id
-      if top_level
-        @inserts.delete id
-      end
+      @inserts.delete(id)
     end
 
     def deletes
@@ -73,7 +71,7 @@ module CouchTap
     end
 
     def insert_values(keys)
-      (@top_level ? @inserts.values : @inserts).map do |data|
+      @inserts.values.flatten.map do |data|
         keys.map { |k| data[k] }
       end
     end

--- a/lib/couch_tap/query_executor.rb
+++ b/lib/couch_tap/query_executor.rb
@@ -6,9 +6,9 @@ module CouchTap
 
     attr_reader :database
 
-    def initialize(db)
-      @database = Sequel.connect(db)
-      @batch_size = 1
+    def initialize(data)
+      @database = Sequel.connect(data.fetch(:db))
+      @batch_size = data.fetch(:batch_size, 1)
       @buffer = QueryBuffer.new
       @ready_to_run = false
       @processing_row = false

--- a/lib/couch_tap/query_executor.rb
+++ b/lib/couch_tap/query_executor.rb
@@ -4,10 +4,8 @@ module CouchTap
 
     attr_reader :database
 
-    def connect(db, name)
-      raise "Cannot have two databases for a changeset!!" if database
+    def initialize(db)
       @database = Sequel.connect(db)
-      find_or_create_sequence_number(name)
     end
 
     def insert(db, attributes)
@@ -18,18 +16,19 @@ module CouchTap
       database[db].where(filter).delete
     end
 
-    def update_sequence(name, seq)
-      database[:couch_sequence].where(:name => name).update(:seq => seq)
+    def update_sequence(seq)
+      database[:couch_sequence].where(:name => @name).update(:seq => seq)
       return seq
     end
 
-    private 
-
     def find_or_create_sequence_number(name)
+      @name = name
       create_sequence_table(name) unless database.table_exists?(:couch_sequence)
       row = database[:couch_sequence].where(:name => name).first
       return (row ? row[:seq] : 0)
     end
+
+    private 
 
     def create_sequence_table(name)
       database.create_table :couch_sequence do

--- a/lib/couch_tap/query_executor.rb
+++ b/lib/couch_tap/query_executor.rb
@@ -1,0 +1,45 @@
+
+module CouchTap
+  class QueryExecutor
+
+    attr_reader :database
+
+    def connect(db, name)
+      raise "Cannot have two databases for a changeset!!" if database
+      @database = Sequel.connect(db)
+      find_or_create_sequence_number(name)
+    end
+
+    def insert(db, attributes)
+      database[db].insert(attributes)
+    end
+
+    def delete(db, filter)
+      database[db].where(filter).delete
+    end
+
+    def update_sequence(name, seq)
+      database[:couch_sequence].where(:name => name).update(:seq => seq)
+      return seq
+    end
+
+    private 
+
+    def find_or_create_sequence_number(name)
+      create_sequence_table(name) unless database.table_exists?(:couch_sequence)
+      row = database[:couch_sequence].where(:name => name).first
+      return (row ? row[:seq] : 0)
+    end
+
+    def create_sequence_table(name)
+      database.create_table :couch_sequence do
+        String :name, :primary_key => true
+        Bignum :seq, :default => 0
+        DateTime :created_at
+        DateTime :updated_at
+      end
+      # Add first row
+      database[:couch_sequence].insert(:name => name)
+    end
+  end
+end

--- a/lib/couch_tap/query_executor.rb
+++ b/lib/couch_tap/query_executor.rb
@@ -28,6 +28,10 @@ module CouchTap
       return (row ? row[:seq] : 0)
     end
 
+    def transaction(&block)
+      database.transaction &block
+    end
+
     private 
 
     def create_sequence_table(name)

--- a/lib/couch_tap/query_executor.rb
+++ b/lib/couch_tap/query_executor.rb
@@ -7,9 +7,14 @@ module CouchTap
     attr_reader :database, :seq
 
     def initialize(name, data)
+      logger.debug "Connecting to db at #{data.fetch :db}"
       @database = Sequel.connect(data.fetch(:db))
       @database.loggers << logger
+      @database.sql_log_level = :debug
+
       @batch_size = data.fetch(:batch_size, 1)
+      logger.debug "Batch size set to #{@batch_size}"
+
       @buffer = QueryBuffer.new
       @ready_to_run = false
       @processing_row = false
@@ -17,52 +22,68 @@ module CouchTap
       @name = name
 
       @seq = find_or_create_sequence_number(name)
+      logger.info "QueryExecutor successfully initialised with sequence: #{@seq}"
     end
 
     def insert(db, top_level, id, attributes)
       raise "Cannot insert outside a row" unless @processing_row
-      if @buffer.insert(db, top_level, id, attributes) >= @batch_size
-        @ready_to_run = true
-      end
+      logger.info "Inserting a #{top_level ? 'top_level' : 'child' } record with id #{id} into #{db}"
+      size = @buffer.insert(db, top_level, id, attributes) 
+      trigger_batch(size)
     end
 
     def delete(db, top_level, filter)
       raise "Cannot delete outside a row" unless @processing_row
-      if @buffer.delete(db, top_level, filter.keys.first, filter.values.first) >= @batch_size
-        @ready_to_run = true
-      end
+      logger.info "Deleting a #{top_level ? 'top_level' : 'child' } record with filter #{filter} from #{db}"
+      size =  @buffer.delete(db, top_level, filter.keys.first, filter.values.first)
+      trigger_batch(size)
     end
 
     def row(seq, &block)
       @seq = seq
+      logger.debug "Processing document with sequence: #{@seq}"
       @processing_row = true
       yield
       @processing_row = false
       if @ready_to_run
+        logger.info "Starting batch!"
         @database.transaction do
           @buffer.each do |entity|
+            logger.debug "Processing queries for #{entity.name}"
             if entity.any_delete?
+              t0 = Time.now
               database[entity.name].where({ entity.primary_key => entity.deletes }).delete
-              logger.info "#{entity.name}: #{entity.deletes.size} rows deleted."
+              logger.info "#{entity.name}: #{entity.deletes.size} rows deleted in #{(Time.now - t0) * 1000} ms."
             end
             if entity.any_insert?
+              t0 = Time.now
               keys = columns(entity.name)
               values = entity.insert_values(keys)
               database[entity.name].import(keys, values)
-              logger.info "#{entity.name}:  #{values.size} rows inserted."
+              logger.info "#{entity.name}:  #{values.size} rows inserted in #{(Time.now - t0) * 1000} ms."
             end
           end
         end
 
+        logger.debug "Changes applied, updating sequence number now to #{@seq}"
         update_sequence(seq)
-        logger.info "#{@name} sequence: #{seq}"
+        logger.info "#{@name}'s new sequence: #{seq}"
 
+        logger.debug "Clearing buffer..."
         @buffer.clear
         @ready_to_run = false
       end
     end
 
     private
+
+    def trigger_batch(size)
+      logger.debug "New buffer's size: #{size}"
+      if size >= @batch_size
+        logger.info "Buffer's size: #{size} reached max size: #{@batch_size}. Triggering batch!!"
+        @ready_to_run = true
+      end
+    end
 
     # TODO unite this cache and the one in changes.rb:48
     # in a common one
@@ -73,15 +94,16 @@ module CouchTap
 
     def find_or_create_sequence_number(name)
       create_sequence_table(name) unless database.table_exists?(:couch_sequence)
-      row = database[:couch_sequence].where(:name => name).first
-      return (row ? row[:seq] : 0)
+      database[:couch_sequence].where(:name => name).first[:seq]
     end
 
     def update_sequence(seq)
+      logger.debug "Updating sequence number for #{@name} to #{seq}"
       database[:couch_sequence].where(:name => @name).update(:seq => seq)
     end
 
     def create_sequence_table(name)
+      logger.debug "Creating :couch_sequence table..."
       database.create_table :couch_sequence do
         String :name, :primary_key => true
         Bignum :seq, :default => 0

--- a/test/functional/functional_changes_test.rb
+++ b/test/functional/functional_changes_test.rb
@@ -1,37 +1,69 @@
-require '../test_helper'
+require 'test_helper'
 
 class FunctionalChangesTest < Test::Unit::TestCase
 
-  def setup
-    # Create a new CouchDB
-    @source = CouchRest.database('couch_tap')
-    create_sample_documents
+  def test_insert_sales_and_nested_entries
+    changes = CouchTap::Changes.new('couch_tap') do 
+      database db: 'sqlite:/', batch_size: 1
 
-    # Create a new Sqlite DB in memory
-    @database = Sequel.sqlite
-    migrate_sample_database
+      document :type => 'Sale' do
+        table :sales do
+          column :audited_at, Time.now
+          collection :entries do
+            table :sale_entries, primary_key: false do
+              column :audited_at, Time.now
+            end
+          end
+        end
+      end
+    end
+
+    migrate_sample_database changes.database
+
+    changes.send(:process_row, { "id" => 1, "seq" => 111, "doc" => { "_id" => "50", "type" => "Sale", "code" => "Code 1", "amount" => 600, "entries" => [{ "price" => 500 }, { "price" => 100 }] }})
+
+    assert_equal 1, changes.database[:sales].count
+    assert_equal 2, changes.database[:sale_entries].count
   end
 
-  def test_something
-    assert_equal "foo", "bar"
+  def test_insert_and_update_sales_and_nested_entries_in_same_batch
+    changes = CouchTap::Changes.new('couch_tap') do
+      database db: 'sqlite:/', batch_size: 10
+
+      document :type => 'Sale' do
+        table :sales do
+          column :audited_at, Time.now
+          collection :entries do
+            table :sale_entries, primary_key: false do
+              column :audited_at, Time.now
+            end
+          end
+        end
+      end
+    end
+
+    migrate_sample_database changes.database
+
+    changes.send(:process_row, { "id" => 1, "seq" => 111, "doc" => { "_id" => "50", "type" => "Sale", "code" => "Code 1", "amount" => 600, "entries" => [{ "price" => 500 }, { "price" => 100 }] }})
+    changes.send(:process_row, { "id" => 2, "seq" => 112, "doc" => { "_id" => "50", "type" => "Sale", "code" => "Code 2", "amount" => 800, "entries" => [{ "price" => 50 }, { "price" => 750 }] }})
+
+    assert_equal 1, changes.database[:sales].count
+    assert_equal 2, changes.database[:sale_entries].count
   end
 
 
   protected
 
-  def migrate_sample_database
-    @database.create_table :items do
-      primary_key :id
-      String :name
-      Float :price
-      Time :created_at
+  def migrate_sample_database(connection)
+    connection.create_table :sales do
+      String :sale_id
+      String :code
+      Float :amount
+    end
+
+    connection.create_table :sale_entries do
+      String :sale_id
+      String :price
     end
   end
-
-  def create_sample_documents
-    @source.save_doc {:name => "Item 1", :price => 1.23, :created_at => Time.now}
-    @source.save_doc {:name => "Item 2", :price => 2.23, :created_at => Time.now}
-    @source.save_doc {:name => "Item 3", :price => 3.23, :created_at => Time.now}
-  end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,5 @@ TEST_DB = CouchRest.database(TEST_DB_ROOT)
 def reset_test_db!
   TEST_DB.recreate!
 end
+
+ENV['log_level'] = Logger::DEBUG.to_s

--- a/test/unit/builders/collection_test.rb
+++ b/test/unit/builders/collection_test.rb
@@ -5,7 +5,7 @@ module Builders
 
     def setup
       @parent = mock()
-      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
     end
 
     def test_initialize_collection

--- a/test/unit/builders/collection_test.rb
+++ b/test/unit/builders/collection_test.rb
@@ -5,7 +5,7 @@ module Builders
 
     def setup
       @parent = mock()
-      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
+      @executor = CouchTap::QueryExecutor.new('changes', db: 'sqlite:/')
     end
 
     def test_initialize_collection

--- a/test/unit/builders/collection_test.rb
+++ b/test/unit/builders/collection_test.rb
@@ -5,6 +5,7 @@ module Builders
 
     def setup
       @parent = mock()
+      @executor = CouchTap::QueryExecutor.new('sqlite:/')
     end
 
     def test_initialize_collection
@@ -66,7 +67,7 @@ module Builders
         table :invoice_items
       end
       @table.expects(:execute).twice
-      @collection.execute
+      @collection.execute(@executor)
     end
 
   end

--- a/test/unit/builders/table_test.rb
+++ b/test/unit/builders/table_test.rb
@@ -4,7 +4,8 @@ module Builders
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @database = create_database
+      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)
       @changes.stubs(:schema).returns(CouchTap::Schema.new(@database, :items))
@@ -65,7 +66,7 @@ module Builders
       @row = CouchTap::Builders::Table.new(@parent, :group_items, :primary_key => false, :data => doc['item_ids'][0]) do
         column :item_id, data
       end
-      @row.execute
+      @row.execute(@executor)
       assert_equal @database[:group_items].first, {:group_id => '1234', :item_id => 'i1234'}
     end
 
@@ -73,7 +74,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute
+      @row.execute(@executor)
 
       items = @database[:items]
       item = items.first
@@ -85,7 +86,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute
+      @row.execute(@executor)
 
       items = @database[:items]
       item = items.first
@@ -94,7 +95,7 @@ module Builders
 
       row = CouchTap::Builders::Table.new(@handler, :items)
       assert_raises Sequel::UniqueConstraintViolation do
-        row.execute
+        row.execute(@executor)
       end
       assert_equal items.where(item_id: '1234').count, 1
     end
@@ -104,7 +105,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234', 'created_at' => time.to_s}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute
+      @row.execute(@executor)
       items = @database[:items]
       item = items.first
       assert item[:created_at].is_a?(Time)
@@ -138,7 +139,7 @@ module Builders
           end
         end
       end
-      @row.execute
+      @row.execute(@executor)
 
       assert_equal @database[:items].where(item_id: '1234').count, 1
       assert_equal @database[:groups].where(item_id: '1234').count, 2
@@ -151,7 +152,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, :full_name
       end
-      @row.execute
+      @row.execute(@executor)
 
       data = @database[:items].first
       assert_equal data[:name], doc['full_name']
@@ -163,7 +164,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, "Force the name"
       end
-      @row.execute
+      @row.execute(@executor)
 
       data = @database[:items].first
       assert_equal data[:name], "Force the name"
@@ -175,7 +176,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, nil
       end
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:name], nil
     end
@@ -184,7 +185,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => 'Some Item Name', 'created_at' => '', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:created_at], nil
     end
@@ -193,7 +194,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => 3, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:count], 3
     end
@@ -202,7 +203,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => '1', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:count], 1
     end
@@ -211,7 +212,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => 1.2, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -221,7 +222,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => '1.2', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute
+      @row.execute(@executor)
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -235,7 +236,7 @@ module Builders
           "Name from block"
         end
       end
-      @row.execute
+      @row.execute(@executor)
 
       data = @database[:items].first
       assert_equal data[:name], "Name from block"
@@ -247,7 +248,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name
       end
-      @row.execute
+      @row.execute(@executor)
 
       data = @database[:items].first
       assert_equal data[:name], doc['name']
@@ -256,9 +257,8 @@ module Builders
 
     protected
 
-    def create_database
-      database = Sequel.sqlite
-      database.create_table :items do
+    def initialize_database(connection)
+      connection.create_table :items do
         String :item_id
         String :name
         Integer :count
@@ -266,7 +266,7 @@ module Builders
         Time :created_at
         index :item_id, :unique => true
       end
-      database
+      connection
     end
 
     def create_many_to_many_items

--- a/test/unit/builders/table_test.rb
+++ b/test/unit/builders/table_test.rb
@@ -4,7 +4,7 @@ module Builders
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
       @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)
@@ -134,7 +134,7 @@ module Builders
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items do
         collection :groups do
-          table :groups, primary_key: 'group_id' do
+          table :groups do
             # Nothing
           end
         end

--- a/test/unit/builders/table_test.rb
+++ b/test/unit/builders/table_test.rb
@@ -4,7 +4,7 @@ module Builders
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
+      @executor = CouchTap::QueryExecutor.new('changes', db: 'sqlite:/')
       @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)
@@ -66,7 +66,7 @@ module Builders
       @row = CouchTap::Builders::Table.new(@parent, :group_items, :primary_key => false, :data => doc['item_ids'][0]) do
         column :item_id, data
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       assert_equal @database[:group_items].first, {:group_id => '1234', :item_id => 'i1234'}
     end
 
@@ -74,7 +74,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       items = @database[:items]
       item = items.first
@@ -86,7 +86,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       items = @database[:items]
       item = items.first
@@ -95,7 +95,7 @@ module Builders
 
       row = CouchTap::Builders::Table.new(@handler, :items)
       assert_raises Sequel::UniqueConstraintViolation do
-        @executor.row { row.execute(@executor) }
+        @executor.row(1) { row.execute(@executor) }
       end
       assert_equal items.where(item_id: '1234').count, 1
     end
@@ -105,7 +105,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234', 'created_at' => time.to_s}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       items = @database[:items]
       item = items.first
       assert item[:created_at].is_a?(Time)
@@ -139,7 +139,7 @@ module Builders
           end
         end
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       assert_equal @database[:items].where(item_id: '1234').count, 1
       assert_equal @database[:groups].where(item_id: '1234').count, 2
@@ -152,7 +152,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, :full_name
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], doc['full_name']
@@ -164,7 +164,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, "Force the name"
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], "Force the name"
@@ -176,7 +176,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, nil
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:name], nil
     end
@@ -185,7 +185,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => 'Some Item Name', 'created_at' => '', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:created_at], nil
     end
@@ -194,7 +194,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => 3, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:count], 3
     end
@@ -203,7 +203,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => '1', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:count], 1
     end
@@ -212,7 +212,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => 1.2, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -222,7 +222,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => '1.2', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -236,7 +236,7 @@ module Builders
           "Name from block"
         end
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], "Name from block"
@@ -248,7 +248,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name
       end
-      @executor.row { @row.execute(@executor) }
+      @executor.row(1) { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], doc['name']

--- a/test/unit/builders/table_test.rb
+++ b/test/unit/builders/table_test.rb
@@ -66,7 +66,7 @@ module Builders
       @row = CouchTap::Builders::Table.new(@parent, :group_items, :primary_key => false, :data => doc['item_ids'][0]) do
         column :item_id, data
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       assert_equal @database[:group_items].first, {:group_id => '1234', :item_id => 'i1234'}
     end
 
@@ -74,7 +74,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       items = @database[:items]
       item = items.first
@@ -86,7 +86,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       items = @database[:items]
       item = items.first
@@ -95,7 +95,7 @@ module Builders
 
       row = CouchTap::Builders::Table.new(@handler, :items)
       assert_raises Sequel::UniqueConstraintViolation do
-        row.execute(@executor)
+        @executor.row { row.execute(@executor) }
       end
       assert_equal items.where(item_id: '1234').count, 1
     end
@@ -105,7 +105,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => "Some Item", '_id' => '1234', 'created_at' => time.to_s}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new(@handler, :items)
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       items = @database[:items]
       item = items.first
       assert item[:created_at].is_a?(Time)
@@ -130,16 +130,16 @@ module Builders
         String :name
       end
       doc = {'type' => 'Item', 'name' => "Some Group", '_id' => '1234',
-        'groups' => [{'name' => 'Group 1'}, {'name' => 'Group 2'},]}
+        'groups' => [{ 'group_id' => 1, 'name' => 'Group 1'}, {'group_id' => 2, 'name' => 'Group 2'}]}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items do
         collection :groups do
-          table :groups do
+          table :groups, primary_key: 'group_id' do
             # Nothing
           end
         end
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       assert_equal @database[:items].where(item_id: '1234').count, 1
       assert_equal @database[:groups].where(item_id: '1234').count, 2
@@ -152,7 +152,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, :full_name
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], doc['full_name']
@@ -164,7 +164,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, "Force the name"
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], "Force the name"
@@ -176,7 +176,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name, nil
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:name], nil
     end
@@ -185,7 +185,7 @@ module Builders
       doc = {'type' => 'Item', 'name' => 'Some Item Name', 'created_at' => '', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:created_at], nil
     end
@@ -194,7 +194,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => 3, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:count], 3
     end
@@ -203,7 +203,7 @@ module Builders
       doc = {'type' => 'Item', 'count' => '1', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:count], 1
     end
@@ -212,7 +212,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => 1.2, '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -222,7 +222,7 @@ module Builders
       doc = {'type' => 'Item', 'price' => '1.2', '_id' => '1234'}
       @handler.document = doc
       @row = CouchTap::Builders::Table.new @handler, :items
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
       data = @database[:items].first
       assert_equal data[:price], 1.2
     end
@@ -236,7 +236,7 @@ module Builders
           "Name from block"
         end
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], "Name from block"
@@ -248,7 +248,7 @@ module Builders
       @row = CouchTap::Builders::Table.new @handler, :items do
         column :name
       end
-      @row.execute(@executor)
+      @executor.row { @row.execute(@executor) }
 
       data = @database[:items].first
       assert_equal data[:name], doc['name']

--- a/test/unit/changes_test.rb
+++ b/test/unit/changes_test.rb
@@ -6,6 +6,7 @@ class ChangesTest < Test::Unit::TestCase
   def setup
     reset_test_db!
     build_sample_config
+    @executor = @changes.instance_variable_get(:@query_executor)
   end
 
   def test_basic_init
@@ -31,8 +32,8 @@ class ChangesTest < Test::Unit::TestCase
     @changes.expects(:fetch_document).with('1234').returns(doc)
 
     handler = @changes.handlers.first
-    handler.expects(:delete).with(doc)
-    handler.expects(:insert).with(doc)
+    handler.expects(:delete).with(doc, @executor)
+    handler.expects(:insert).with(doc, @executor)
 
     @changes.send(:process_row, row)
 
@@ -62,7 +63,7 @@ class ChangesTest < Test::Unit::TestCase
     row = {'seq' => 9, 'id' => '1234', 'deleted' => true}
 
     @changes.handlers.each do |handler|
-      handler.expects(:delete).with({'_id' => row['id']})
+      handler.expects(:delete).with({'_id' => row['id']}, @executor)
     end
 
     @changes.send(:process_row, row)

--- a/test/unit/changes_test.rb
+++ b/test/unit/changes_test.rb
@@ -37,10 +37,10 @@ class ChangesTest < Test::Unit::TestCase
     @changes.send(:process_row, row)
 
     # Should update seq
-    assert_equal @changes.database[:couch_sequence].first[:seq], 1
+    assert_equal @changes.seq, 1
   end
 
-  def test_inserting_rows_with_mutiple_filters
+  def test_inserting_rows_with_multiple_filters
     doc = {'_id' => '1234', 'type' => 'Bar', 'special' => true, 'name' => 'Some Document'}
     row = {'seq' => 3, 'id' => '1234', 'doc' => doc}
 
@@ -54,7 +54,7 @@ class ChangesTest < Test::Unit::TestCase
     handler.expects(:insert)
 
     @changes.send(:process_row, row)
-    assert_equal @changes.database[:couch_sequence].first[:seq], 3
+    assert_equal @changes.seq, 3
   end
 
   def test_deleting_rows
@@ -66,8 +66,7 @@ class ChangesTest < Test::Unit::TestCase
 
     @changes.send(:process_row, row)
 
-    p @changes.database[:couch_sequence].to_a
-    assert_equal @changes.database[:couch_sequence].first[:seq], 9
+    assert_equal @changes.seq, 9
   end
 
   def test_returning_schema

--- a/test/unit/changes_test.rb
+++ b/test/unit/changes_test.rb
@@ -66,6 +66,7 @@ class ChangesTest < Test::Unit::TestCase
 
     @changes.send(:process_row, row)
 
+    p @changes.database[:couch_sequence].to_a
     assert_equal @changes.database[:couch_sequence].first[:seq], 9
   end
 

--- a/test/unit/changes_test.rb
+++ b/test/unit/changes_test.rb
@@ -27,9 +27,8 @@ class ChangesTest < Test::Unit::TestCase
   end
 
   def test_inserting_rows
-    row = {'seq' => 1, 'id' => '1234'}
     doc = {'_id' => '1234', 'type' => 'Foo', 'name' => 'Some Document'}
-    @changes.expects(:fetch_document).with('1234').returns(doc)
+    row = {'seq' => 1, 'id' => '1234', 'doc' => doc}
 
     handler = @changes.handlers.first
     handler.expects(:delete).with(doc, @executor)
@@ -42,9 +41,8 @@ class ChangesTest < Test::Unit::TestCase
   end
 
   def test_inserting_rows_with_mutiple_filters
-    row = {'seq' => 3, 'id' => '1234'}
     doc = {'_id' => '1234', 'type' => 'Bar', 'special' => true, 'name' => 'Some Document'}
-    @changes.expects(:fetch_document).with('1234').returns(doc)
+    row = {'seq' => 3, 'id' => '1234', 'doc' => doc}
 
     handler = @changes.handlers[0]
     handler.expects(:insert).never

--- a/test/unit/changes_test.rb
+++ b/test/unit/changes_test.rb
@@ -83,7 +83,7 @@ class ChangesTest < Test::Unit::TestCase
 
   def build_sample_config
     @changes = CouchTap::Changes.new(TEST_DB_ROOT) do
-      database "sqlite:/"
+      database db: "sqlite:/"
       document :type => 'Foo' do
       end
       document :type => 'Bar' do

--- a/test/unit/destroyers/collection_test.rb
+++ b/test/unit/destroyers/collection_test.rb
@@ -5,7 +5,7 @@ module Destroyers
 
     def setup
       @parent = mock()
-      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
+      @executor = CouchTap::QueryExecutor.new('changes', db: 'sqlite:/')
     end
 
     def test_initialize_collection
@@ -51,6 +51,5 @@ module Destroyers
       @table.expects(:execute)
       @collection.execute(@executor)
     end
-
   end
 end

--- a/test/unit/destroyers/collection_test.rb
+++ b/test/unit/destroyers/collection_test.rb
@@ -5,6 +5,7 @@ module Destroyers
 
     def setup
       @parent = mock()
+      @executor = CouchTap::QueryExecutor.new('sqlite:/')
     end
 
     def test_initialize_collection
@@ -48,7 +49,7 @@ module Destroyers
         table :invoice_items
       end
       @table.expects(:execute)
-      @collection.execute
+      @collection.execute(@executor)
     end
 
   end

--- a/test/unit/destroyers/collection_test.rb
+++ b/test/unit/destroyers/collection_test.rb
@@ -5,7 +5,7 @@ module Destroyers
 
     def setup
       @parent = mock()
-      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
     end
 
     def test_initialize_collection

--- a/test/unit/destroyers/table_test.rb
+++ b/test/unit/destroyers/table_test.rb
@@ -5,7 +5,7 @@ module Destroyers
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
+      @executor = CouchTap::QueryExecutor.new('changes', db: 'sqlite:/')
       @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)
@@ -63,7 +63,7 @@ module Destroyers
       @database[:items].insert(:name => "Test Item 1", :item_id => "12345")
       assert_equal @database[:items].count, 1, "Did not create sample row correctly!"
       @row = CouchTap::Destroyers::Table.new(@handler, :items)
-      @executor.row do
+      @executor.row 1 do
         @row.execute(@executor)
       end
       assert_equal 0, @database[:items].count
@@ -81,7 +81,7 @@ module Destroyers
         end
       end
       @col.expects(:execute).twice
-      @executor.row do
+      @executor.row 1 do
         @row.execute(@executor)
       end
     end

--- a/test/unit/destroyers/table_test.rb
+++ b/test/unit/destroyers/table_test.rb
@@ -5,7 +5,7 @@ module Destroyers
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
       @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)

--- a/test/unit/destroyers/table_test.rb
+++ b/test/unit/destroyers/table_test.rb
@@ -63,7 +63,9 @@ module Destroyers
       @database[:items].insert(:name => "Test Item 1", :item_id => "12345")
       assert_equal @database[:items].count, 1, "Did not create sample row correctly!"
       @row = CouchTap::Destroyers::Table.new(@handler, :items)
-      @row.execute(@executor)
+      @executor.row do
+        @row.execute(@executor)
+      end
       assert_equal 0, @database[:items].count
     end
 
@@ -79,7 +81,9 @@ module Destroyers
         end
       end
       @col.expects(:execute).twice
-      @row.execute(@executor)
+      @executor.row do
+        @row.execute(@executor)
+      end
     end
 
     def test_column_returns_nil

--- a/test/unit/destroyers/table_test.rb
+++ b/test/unit/destroyers/table_test.rb
@@ -5,7 +5,8 @@ module Destroyers
   class TableTest < Test::Unit::TestCase
 
     def setup
-      @database = create_database
+      @executor = CouchTap::QueryExecutor.new('sqlite:/')
+      @database = initialize_database(@executor.database)
       @changes = mock()
       @changes.stubs(:database).returns(@database)
       @changes.stubs(:schema).returns(CouchTap::Schema.new(@database, :items))
@@ -62,7 +63,7 @@ module Destroyers
       @database[:items].insert(:name => "Test Item 1", :item_id => "12345")
       assert_equal @database[:items].count, 1, "Did not create sample row correctly!"
       @row = CouchTap::Destroyers::Table.new(@handler, :items)
-      @row.execute
+      @row.execute(@executor)
       assert_equal 0, @database[:items].count
     end
 
@@ -78,7 +79,7 @@ module Destroyers
         end
       end
       @col.expects(:execute).twice
-      @row.execute
+      @row.execute(@executor)
     end
 
     def test_column_returns_nil
@@ -100,21 +101,20 @@ module Destroyers
 
     protected
 
-    def create_database
-      database = Sequel.sqlite
-      database.create_table :items do
+    def initialize_database(connection)
+      connection.create_table :items do
         String :item_id
         String :name
         Time :created_at
         index :item_id, :unique => true
       end
-      database.create_table :groups do
+      connection.create_table :groups do
         String :group_id
         String :name
         Time :created_at
         index :group_id, :unique => true
       end
-      database
+      connection
     end
   end
 end

--- a/test/unit/document_handler_test.rb
+++ b/test/unit/document_handler_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 class DocumentHandlerTest < Test::Unit::TestCase
 
   def test_init
+    @executor = CouchTap::QueryExecutor.new('sqlite:/')
     @handler = CouchTap::DocumentHandler.new 'changes' do
       #nothing
     end
@@ -42,7 +43,7 @@ class DocumentHandlerTest < Test::Unit::TestCase
     end
     @handler.expects(:table).with(:items)
     doc = {'type' => 'Foo', '_id' => '1234'}
-    @handler.insert(doc)
+    @handler.insert(doc, @executor)
     assert_equal @handler.document, doc
   end
 
@@ -51,7 +52,7 @@ class DocumentHandlerTest < Test::Unit::TestCase
       table :items
     end
     @handler.expects(:table).with(:items)
-    @handler.delete('_id' => '1234')
+    @handler.delete({ '_id' => '1234' }, @executor)
     assert_equal @handler.id, '1234'
   end
 

--- a/test/unit/document_handler_test.rb
+++ b/test/unit/document_handler_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class DocumentHandlerTest < Test::Unit::TestCase
 
   def test_init
-    @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
+    @executor = CouchTap::QueryExecutor.new('changes', db: 'sqlite:/')
     @handler = CouchTap::DocumentHandler.new 'changes' do
       #nothing
     end

--- a/test/unit/document_handler_test.rb
+++ b/test/unit/document_handler_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class DocumentHandlerTest < Test::Unit::TestCase
 
   def test_init
-    @executor = CouchTap::QueryExecutor.new('sqlite:/')
+    @executor = CouchTap::QueryExecutor.new(db: 'sqlite:/')
     @handler = CouchTap::DocumentHandler.new 'changes' do
       #nothing
     end

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -92,5 +92,13 @@ class EntityTest < Test::Unit::TestCase
       entity.delete('another_key', 123)
     end
   end
+
+  def test_delete_removes_from_insertions_list_if_top_level
+    entity = CouchTap::Entity.new('dummy', true)
+    entity.insert(123, a: 1, b: 'c')
+    entity.delete('dummy_id', 123)
+
+    refute entity.any_insert?
+  end
 end
 

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -100,5 +100,13 @@ class EntityTest < Test::Unit::TestCase
 
     refute entity.any_insert?
   end
+
+  def test_delete_removes_from_insertions_list_if_child
+    entity = CouchTap::Entity.new('dummy', false)
+    entity.insert(123, a: 1, b: 'c')
+    entity.delete('dummy_id', 123)
+
+    refute entity.any_insert?
+  end
 end
 

--- a/test/unit/entity_test.rb
+++ b/test/unit/entity_test.rb
@@ -1,0 +1,96 @@
+
+require 'test_helper'
+
+class EntityTest < Test::Unit::TestCase
+
+  def test_insert_saves_a_top_level_entity
+    id = 123
+    data = { id: id, a: 1, b: "b" }
+    entity = CouchTap::Entity.new('dummy', true)
+    entity.insert(id, data)
+    assert_equal [[id, 1, "b"]], entity.insert_values(data.keys)
+  end
+
+  def test_insert_saves_a_non_top_level
+    id = 123
+    data = { id: id, a: 1, b: "b" }
+    entity = CouchTap::Entity.new('dummy', false)
+    entity.insert(id, data)
+    assert_equal [[id, 1, "b"]], entity.insert_values(data.keys)
+  end
+
+  def test_insert_overrides_a_top_level_with_same_key
+    id = 123
+    data = { id: id, a: 1, b: "b" }
+    data2 = { id: id, a: 2, b: "c" }
+    entity = CouchTap::Entity.new('dummy', true)
+
+    entity.insert(id, data)
+    entity.insert(id, data2)
+
+    assert_equal [[id, 2, "c"]], entity.insert_values(data.keys)
+  end
+
+  def test_insert_appends_a_non_top_level
+    id = 123
+    data = { id: id, a: 1, b: "b" }
+    data2 = { id: id, a: 2, b: "c" }
+    entity = CouchTap::Entity.new('dummy', false)
+
+    entity.insert(id, data)
+    entity.insert(id, data2)
+
+    assert_equal [[id, 1, "b"], [id, 2, "c"]], entity.insert_values(data.keys)
+  end
+
+  def test_insert_values_brings_nil_for_unmatched_keys
+    id = 123
+    data = { id: id, a: 1, b: "b" }
+    entity = CouchTap::Entity.new('dummy', true)
+
+    entity.insert(id, data)
+
+    assert_equal [[nil, id, nil, 1, nil, "b", nil]], entity.insert_values([:c, :id, :d, :a, :e, :b, :f])
+  end
+
+  def test_delete_saves_the_entity_id
+    id = 123
+    id2 = 234
+    entity = CouchTap::Entity.new('dummy', true)
+
+    entity.delete('dummy_id', id)
+    entity.delete('dummy_id', id2)
+
+    assert_equal [id, id2], entity.deletes
+  end
+
+  def test_delete_removes_duplicate_ids
+    id = 123
+    entity = CouchTap::Entity.new('dummy', true)
+
+    entity.delete('dummy_id', id)
+    entity.delete('dummy_id', id)
+
+    assert_equal [id], entity.deletes
+  end
+
+  def test_delete_sets_the_pk
+    key = 'dummy_id'
+    entity = CouchTap::Entity.new('dummy', true)
+    entity.delete(key, 123)
+
+    assert_equal key, entity.primary_key
+  end
+
+  def test_delete_protects_against_different_pks
+    key = 'dummy_id'
+    entity = CouchTap::Entity.new('dummy', true)
+    entity.delete(key, 123)
+
+    assert_equal key, entity.primary_key
+    assert_raises RuntimeError  do
+      entity.delete('another_key', 123)
+    end
+  end
+end
+

--- a/test/unit/query_buffer_test.rb
+++ b/test/unit/query_buffer_test.rb
@@ -137,4 +137,30 @@ class QueryBufferTest < Test::Unit::TestCase
     buffer.each { |e| entity_names << e.name }
     assert_equal %w(dummy another), entity_names
   end
+
+  def test_top_level_items_are_overwritten
+    buffer = CouchTap::QueryBuffer.new
+
+    buffer.insert('dummy', true, 123, a: 1, b: 'c')
+    buffer.insert('dummy', true, 123, a: 2, b: 'd')
+
+    entities = []
+    buffer.each { |e| entities << e }
+
+    assert_equal 1, entities.count
+    assert_equal [[2, 'd']], entities.first.insert_values(%i(a b))
+  end
+
+  def test_child_elements_are_deleted
+    buffer = CouchTap::QueryBuffer.new
+
+    buffer.insert('dummy', false, 123, a: 1, b: 'c')
+    buffer.delete('dummy', false, 'dummy_id', 123)
+
+    entities = []
+    buffer.each { |e| entities << e }
+
+    assert_equal 1, entities.count
+    refute entities.first.any_insert?
+  end
 end

--- a/test/unit/query_buffer_test.rb
+++ b/test/unit/query_buffer_test.rb
@@ -1,0 +1,140 @@
+
+require 'test_helper'
+
+class QueryBufferTest < Test::Unit::TestCase
+
+  def test_insert_adds_data_to_be_inserted
+    buffer = CouchTap::QueryBuffer.new
+
+    id = 123
+    data = { a: 1, b: 'b' }
+
+    entity = mock(top_level: true)
+    entity.expects(:insert).with(id, data)
+
+    CouchTap::Entity.expects(:new).with('dummy', true).returns(entity)
+
+    buffer.insert('dummy', true, id, data)
+  end
+
+  def test_insert_reuses_entities_with_same_name
+    buffer = CouchTap::QueryBuffer.new
+
+    id = 123
+    data = { a: 1, b: 'b' }
+
+    id2 = 987
+    data2 = { a: 2, b: 'c' }
+
+    entity = mock()
+    entity.expects(:top_level).twice.returns(true)
+    entity.expects(:insert).with(id, data)
+    entity.expects(:insert).with(id2, data2)
+
+    CouchTap::Entity.expects(:new).with('dummy', true).returns(entity)
+
+    buffer.insert('dummy', true, id, data)
+    buffer.insert('dummy', true, id2, data2)
+  end
+
+  def test_insert_cannot_have_same_entity_as_both_top_level_and_dependent
+    buffer = CouchTap::QueryBuffer.new
+
+    buffer.insert('dummy', true, 123, a: 1, b: 'b')
+    assert_raises ArgumentError do
+      buffer.insert('dummy', false, 123, a: 1, b: 'b')
+    end
+  end
+
+  def test_insert_increases_size
+    buffer = CouchTap::QueryBuffer.new
+
+    assert_equal 1, buffer.insert('dummy', true, 123, a: 1, b: 'b')
+    assert_equal 2, buffer.insert('dummy', true, 123, a: 1, b: 'b')
+  end
+
+  def test_delete_adds_data_to_be_deleted
+    buffer = CouchTap::QueryBuffer.new
+
+    id = 123
+    key = 'dummy_id'
+
+    entity = mock(top_level: true)
+    entity.expects(:delete).with(key, id)
+
+    CouchTap::Entity.expects(:new).with('dummy', true).returns(entity)
+
+    buffer.delete('dummy', true, key, id)
+  end
+
+  def test_delete_reuses_entities_with_same_name
+    buffer = CouchTap::QueryBuffer.new
+
+    id = 123
+    id2 = 987
+    key = 'dummy_id'
+
+    entity = mock()
+    entity.expects(:top_level).twice.returns(true)
+    entity.expects(:delete).with(key, id)
+    entity.expects(:delete).with(key, id2)
+
+    CouchTap::Entity.expects(:new).with('dummy', true).returns(entity)
+
+    buffer.delete('dummy', true, key, id)
+    buffer.delete('dummy', true, key, id2)
+  end
+
+  def test_delete_cannot_have_same_entity_as_both_top_level_and_dependent
+    buffer = CouchTap::QueryBuffer.new
+
+    buffer.delete('dummy', true, 'dummy_id', 123)
+    assert_raises ArgumentError do
+      buffer.delete('dummy', false, 'dummy_id',  987)
+    end
+  end
+
+  def test_delete_increases_size
+    buffer = CouchTap::QueryBuffer.new
+
+    assert_equal 1, buffer.delete('dummy', true, 'dummy_id', 123)
+    assert_equal 2, buffer.delete('dummy', true, 'dummy_id', 987)
+  end
+
+  def test_clear_resets_the_size
+    buffer = CouchTap::QueryBuffer.new
+
+    assert_equal 1, buffer.insert('dummy', true, 123, a: 1, b: 'c')
+    assert_equal 2, buffer.delete('dummy', true, 'dummy_id', 987)
+    buffer.clear
+    assert_equal 1, buffer.insert('dummy', true, 123, a: 1, b: 'c')
+  end
+
+  def test_clear_clears_the_buffer
+    buffer = CouchTap::QueryBuffer.new
+
+    assert_equal 1, buffer.insert('dummy', true, 123, a: 1, b: 'c')
+    assert_equal 2, buffer.delete('another', true, 'another_id', 987)
+
+    items = 0
+    buffer.each { |i| items += 1 }
+    assert_equal 2, items
+
+    buffer.clear
+
+    items = 0
+    buffer.each { |i| items += 1 }
+    assert_equal 0, items
+  end
+
+  def test_can_iterate_over_entities
+    buffer = CouchTap::QueryBuffer.new
+
+    assert_equal 1, buffer.insert('dummy', true, 123, a: 1, b: 'c')
+    assert_equal 2, buffer.delete('another', true, 'another_id', 987)
+
+    entity_names = []
+    buffer.each { |e| entity_names << e.name }
+    assert_equal %w(dummy another), entity_names
+  end
+end

--- a/test/unit/query_executor_test.rb
+++ b/test/unit/query_executor_test.rb
@@ -1,0 +1,159 @@
+
+require 'test_helper'
+
+class QueryExecutorTest < Test::Unit::TestCase
+
+  def test_insert_saves_the_data_if_not_full
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+
+    executor.row do
+      executor.insert(:items, true, 123, item_id: 123, name: 'dummy')
+    end
+
+    assert_equal 0, executor.database[:items].count
+  end
+
+  def test_cannot_insert_outside_a_row_document
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+
+    assert_raises RuntimeError do
+      executor.insert(:items, true, 123, item_id: 123, name: 'dummy')
+    end
+
+    assert_equal 0, executor.database[:items].count
+  end
+
+  def test_insert_runs_the_query_if_full
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    initialize_database executor.database
+
+    executor.row do
+      executor.insert(:items, true, 123, item_id: 123, name: 'dummy')
+      executor.insert(:items, true, 987, item_id: 987, name: 'dummy')
+    end
+
+    assert_equal 2, executor.database[:items].count
+  end
+
+  def test_delete_saves_the_data_if_not_full
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+
+    id = 123
+
+    executor.database[:items].insert(item_id: id, name: 'dummy')
+    assert_equal 1, executor.database[:items].count
+
+    executor.row do
+      executor.delete(:items, true, item_id: id)
+    end
+
+    assert_equal 1, executor.database[:items].count
+  end
+
+  def test_delete_runs_the_query_if_full
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 1
+    initialize_database executor.database
+
+    id = 123
+
+    executor.database[:items].insert(item_id: id, name: 'dummy')
+    assert_equal 1, executor.database[:items].count
+
+    executor.row do
+      executor.delete(:items, true, item_id: id)
+    end
+
+    assert_equal 0, executor.database[:items].count
+  end
+
+  def test_create_and_delete_in_same_row
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    initialize_database executor.database
+
+    executor.row do
+      executor.insert(:items, true, 123, item_id: 123, a: 1, b: 'b')
+      executor.delete(:items, true, item_id: 123)
+    end
+
+    assert_equal 0, executor.database[:items].where(item_id: 123).count
+  end
+
+  def test_includes_whole_row_even_if_batch_gets_oversized
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    initialize_database executor.database
+
+    executor.row do
+      executor.insert(:items, true, 123, item_id: 123, count: 1, name: 'b')
+      executor.insert(:items, true, 234, item_id: 234, count: 2, name: 'c')
+      executor.insert(:items, true, 345, item_id: 345, count: 3, name: 'd')
+      executor.insert(:items, true, 456, item_id: 456, count: 4, name: 'e')
+    end
+
+    assert_equal 4, executor.database[:items].count
+  end
+
+  def test_combined_workload
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 3
+    initialize_database executor.database
+
+    executor.row do
+      # Create and destroy item 123
+      executor.insert(:items, true, 123, item_id: 123, count: 1, name: 'b')
+      executor.delete(:items, true, item_id: 123)
+
+      # Insert items 234, 345 and 456
+      executor.insert(:items, true, 234, item_id: 234, count: 2, name: 'c')
+      executor.insert(:items, true, 345, item_id: 345, count: 3, name: 'd')
+      executor.insert(:items, true, 456, item_id: 456, count: 4, name: 'e')
+    end
+
+    executor.row do
+      # Update item 234
+      executor.delete(:items, true, item_id: 234)
+      executor.insert(:items, true, 234, item_id: 234, count: 4, name: 'new')
+
+      # Delete item 345
+      executor.delete(:items, true, item_id: 345)
+    end
+
+    expected = [
+      { item_id: "456", name: "e", count: 4, price: nil, created_at: nil }, 
+      { item_id: "234", name: "new", count: 4, price: nil, created_at: nil }
+    ]
+
+    assert_equal expected, executor.database[:items].to_a
+  end
+
+  def test_cannot_delete_outside_a_row_document
+    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+
+    id = 123
+
+    executor.database[:items].insert(item_id: id, name: 'dummy')
+    assert_equal 1, executor.database[:items].count
+
+    assert_raises RuntimeError do
+      executor.delete(:items, true, item_id: 123)
+    end
+
+    assert_equal 1, executor.database[:items].count
+  end
+
+  private
+
+  def initialize_database(connection)
+    connection.create_table :items do
+      String :item_id
+      String :name
+      Integer :count
+      Float :price
+      Time :created_at
+      index :item_id, :unique => true
+    end
+    connection
+  end
+end

--- a/test/unit/query_executor_test.rb
+++ b/test/unit/query_executor_test.rb
@@ -4,10 +4,10 @@ require 'test_helper'
 class QueryExecutorTest < Test::Unit::TestCase
 
   def test_insert_saves_the_data_if_not_full
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
     initialize_database executor.database
 
-    executor.row do
+    executor.row 1 do
       executor.insert(:items, true, 123, item_id: 123, name: 'dummy')
     end
 
@@ -15,7 +15,7 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_cannot_insert_outside_a_row_document
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
     initialize_database executor.database
 
     assert_raises RuntimeError do
@@ -26,10 +26,10 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_insert_runs_the_query_if_full
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 2
     initialize_database executor.database
 
-    executor.row do
+    executor.row 1 do
       executor.insert(:items, true, 123, item_id: 123, name: 'dummy')
       executor.insert(:items, true, 987, item_id: 987, name: 'dummy')
     end
@@ -38,7 +38,7 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_delete_saves_the_data_if_not_full
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
     initialize_database executor.database
 
     id = 123
@@ -46,7 +46,7 @@ class QueryExecutorTest < Test::Unit::TestCase
     executor.database[:items].insert(item_id: id, name: 'dummy')
     assert_equal 1, executor.database[:items].count
 
-    executor.row do
+    executor.row 1 do
       executor.delete(:items, true, item_id: id)
     end
 
@@ -54,7 +54,7 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_delete_runs_the_query_if_full
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 1
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 1
     initialize_database executor.database
 
     id = 123
@@ -62,7 +62,7 @@ class QueryExecutorTest < Test::Unit::TestCase
     executor.database[:items].insert(item_id: id, name: 'dummy')
     assert_equal 1, executor.database[:items].count
 
-    executor.row do
+    executor.row 1 do
       executor.delete(:items, true, item_id: id)
     end
 
@@ -70,10 +70,10 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_create_and_delete_in_same_row
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 2
     initialize_database executor.database
 
-    executor.row do
+    executor.row 1 do
       executor.insert(:items, true, 123, item_id: 123, a: 1, b: 'b')
       executor.delete(:items, true, item_id: 123)
     end
@@ -82,10 +82,10 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_includes_whole_row_even_if_batch_gets_oversized
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 2
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 2
     initialize_database executor.database
 
-    executor.row do
+    executor.row 1 do
       executor.insert(:items, true, 123, item_id: 123, count: 1, name: 'b')
       executor.insert(:items, true, 234, item_id: 234, count: 2, name: 'c')
       executor.insert(:items, true, 345, item_id: 345, count: 3, name: 'd')
@@ -96,10 +96,10 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_combined_workload
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 3
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 3
     initialize_database executor.database
 
-    executor.row do
+    executor.row 1 do
       # Create and destroy item 123
       executor.insert(:items, true, 123, item_id: 123, count: 1, name: 'b')
       executor.delete(:items, true, item_id: 123)
@@ -110,7 +110,7 @@ class QueryExecutorTest < Test::Unit::TestCase
       executor.insert(:items, true, 456, item_id: 456, count: 4, name: 'e')
     end
 
-    executor.row do
+    executor.row 2 do
       # Update item 234
       executor.delete(:items, true, item_id: 234)
       executor.insert(:items, true, 234, item_id: 234, count: 4, name: 'new')
@@ -128,7 +128,7 @@ class QueryExecutorTest < Test::Unit::TestCase
   end
 
   def test_cannot_delete_outside_a_row_document
-    executor = CouchTap::QueryExecutor.new db: 'sqlite:/', batch_size: 10
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
     initialize_database executor.database
 
     id = 123
@@ -141,6 +141,47 @@ class QueryExecutorTest < Test::Unit::TestCase
     end
 
     assert_equal 1, executor.database[:items].count
+  end
+
+  def test_sequence_number_defaults_to_zero
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+    assert_equal 0, executor.seq
+  end
+
+  def test_sequence_number_is_loaded_on_initialization
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite://test.db', batch_size: 10
+    initialize_database executor.database
+    executor.database[:couch_sequence].where(name: 'items').update(seq: 432)
+
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite://test.db', batch_size: 10
+    assert_equal 432, executor.seq
+
+    File.delete('test.db')
+  end
+
+  def test_sequence_number_is_kept_in_memory_if_no_transaction
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 10
+    initialize_database executor.database
+
+    executor.row 500 do
+      executor.insert(:items, true, 123, item_id: 123, name: 'n')
+    end
+
+    assert_equal 500, executor.seq
+    assert_equal 0, executor.database[:couch_sequence].where(name: 'items').first[:seq]
+  end
+
+  def test_sequence_number_is_saved_upon_transaction
+    executor = CouchTap::QueryExecutor.new 'items', db: 'sqlite:/', batch_size: 1
+    initialize_database executor.database
+
+    executor.row 500 do
+      executor.insert(:items, true, 123, item_id: 123, name: 'n')
+    end
+
+    assert_equal 500, executor.seq
+    assert_equal 500, executor.database[:couch_sequence].where(name: 'items').first[:seq]
   end
 
   private


### PR DESCRIPTION
Delegates all database interaction to the `QueryExecutor` class. Buffers operations in the `QueryBuffer` and runs them all in batches when the configured size is reached.

Upon deletion, both the record and its possible children are deleted from the buffer. This may happen if the same record is received twice (or more) during the same batch or if we receive a `delete` change from Couch.