### PR TITLE
Set proper required version of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,9 @@ rvm:
 services:
   - docker
 env:
-  - COUCHDB_IMAGE=klaemo/couchdb # CouchDB 2.0.0
   - COUCHDB_IMAGE=couchdb        # Couchdb 1.6
 matrix:
   include:
-    - rvm: "2.4"
-      gemfile: gemfiles/Gemfile_2_4
-      services:
-        - docker
-      env: COUCHDB_IMAGE=klaemo/couchdb
     - rvm: "2.4"
       gemfile: gemfiles/Gemfile_2_4
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: required
 language: ruby
 rvm:
+  - 2.4
   - 2.3
-  - 2.2
-  - 2.1
-  - 2.0
 services:
   - docker
 env:

--- a/couch_tap.gemspec
+++ b/couch_tap.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Sam Lown"]
   s.email         = 'me@samlown.com'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Story: [ch130714](https://app.clubhouse.io/cabify/story/130714/install-ruby-2-3-x-in-couchtap-machines)

With the addition of the latest version of `byebug`, we need to increase the required version of Ruby.